### PR TITLE
Rename "Paylaşım" to "Gönderi"

### DIFF
--- a/client/src/Main/Profile/Profile.js
+++ b/client/src/Main/Profile/Profile.js
@@ -49,7 +49,7 @@ const UserInformation = props => {
           <View style={styles.stats}>
             <View style={styles.stat}>
               <Text style={styles.statNumber}>{props.user.postCount}</Text>
-              <Text style={styles.statName}>Paylaşım</Text>
+              <Text style={styles.statName}>Gönderi</Text>
             </View>
             <View style={styles.stat}>
               <Text style={styles.statNumber}>{props.user.followersCount}</Text>


### PR DESCRIPTION
Paylaşım başlık/konu ve gönderi anlamına gelebildiği için neyi saydığı konusunda karışıklık yaratabilir. Gönderi başlıklar altındakiler olduğundan ve post kelimesinin doğru Türkçe çevirisi olduğu için daha mantıklı.